### PR TITLE
Created utility methods for separating out vendor files from entry ch…

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "license": "MIT",
   "dependencies": {
     "jquery": "^3.1.1",
-    "path": "^0.12.7"
+    "lodash": "^4.17.4",
+    "path": "^0.12.7",
+    "react": "^15.4.2"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.3",

--- a/src/about/index.js
+++ b/src/about/index.js
@@ -1,1 +1,3 @@
+import $ from 'jquery';
+import _ from 'lodash/extend';
 import './index.css';

--- a/src/top/index.js
+++ b/src/top/index.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import React from 'react';
 import './index.css';
 
 $('body').addClass('hi');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,22 @@ var StyleLintPlugin = require('stylelint-webpack-plugin')
 var WebpackMd5Hash = require('webpack-md5-hash')
 var ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
 var InlineChunkWebpackPlugin = require('html-webpack-inline-chunk-plugin')
+const { getVendorsFromEntries, getExcludedChunkName } = require('./webpackUtils');
+
+const entries =  {
+	top: './src/top/index.js',
+	about: './src/about/index.js',
+};
+
+const entryVendorChunks = getVendorsFromEntries(entries);
+// return something like this:
+// new webpack.optimize.CommonsChunkPlugin({
+//   name: 'vendor.top',
+//   chunks: ['top'],
+//   minChunks: ({ resource }) => {
+//   	return /node_modules/.test(resource);
+//   },
+// }),
 
 module.exports = {
 
@@ -19,10 +35,7 @@ module.exports = {
 		chunkModules: true
 	},
 
-	entry: {
-		top: './src/top/index.js',
-		about: './src/about/index.js',
-	},
+	entry: entries,
 
 	output: {
 		path: path.resolve(__dirname, 'dist'),
@@ -79,7 +92,7 @@ module.exports = {
 		]
 	},
 
-	plugins: [
+	plugins: entryVendorChunks.concat([
 
 		new webpack.optimize.OccurrenceOrderPlugin(),
 
@@ -95,7 +108,7 @@ module.exports = {
 
 		// Top page
 		new HtmlWebpackPlugin({
-			excludeChunks: ['about'],
+			excludeChunks: getExcludedChunkName(['about']),
 			template: './src/top/index.pug',
 			filename: 'index.html',
 			chunksSortMode: 'dependency',
@@ -103,23 +116,18 @@ module.exports = {
 
 		// About page
 		new HtmlWebpackPlugin({
-			excludeChunks: ['top'],
+			excludeChunks: getExcludedChunkName(['top']),
 			template: './src/about/index.pug',
 			filename: 'about.html',
 			chunksSortMode: 'dependency',
 		}),
 
 		new webpack.optimize.CommonsChunkPlugin({
-		  name: 'vendor',
-		  minChunks: ({ resource }) => /node_modules/.test(resource),
-		}),
-
-		new webpack.optimize.CommonsChunkPlugin({
-			name: ['commons', 'vendor', 'bootstrap'],
+			name: ['commons', 'bootstrap'],
 		}),
 
 		// new webpack.optimize.UglifyJsPlugin(),
 
 		new WebpackMd5Hash(),
-	]
+	])
 }

--- a/webpackUtils.js
+++ b/webpackUtils.js
@@ -1,0 +1,22 @@
+const webpack = require('webpack');
+
+const getVendorName = entryName => `vendors.${entryName}`;
+
+exports.getVendorsFromEntries = function(entries) {
+	return Object
+		.keys(entries)
+		.map(entryName => 
+			new webpack.optimize.CommonsChunkPlugin({
+			  name: getVendorName(entryName),
+			  chunks: [entryName],
+			  minChunks: ({ resource }) => {
+			  	return /node_modules/.test(resource);
+			  },
+			})
+		);
+};
+
+exports.getExcludedChunkName = function(chunksToBeExcluded) {
+	return chunksToBeExcluded.reduce((excluded, chunkName) => 
+		excluded.concat(chunkName, getVendorName(chunkName)), []);
+};


### PR DESCRIPTION
Hey Ryo, 
With the setup you have there, yes it won't really work that way. The commons chunk is expecting to only pull code out that exists across entries. Therefore if the module only exists in one entry, it doesn't see the need to extract it. 
That's why we often must explicitly declare a vendors chunk. 
However that's not enough in your case, since you want to extract all vendor files from each entry, into their own **separate** chunks. This is the key, as again by default commons chunk will bundle things together. Creating more common chunks will just simply pass that code along.

What we need to do is create explicit chunks for each entry. It's a little more work but after playing with it I finally got it to work. Check it out!
